### PR TITLE
Add Fyers OAuth callback page with manual auth code flow

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -46,6 +46,7 @@ const App = () => (
           <BrowserRouter>
             <Routes>
               <Route path="/login" element={<Login />} />
+              <Route path="/fyers/callback" element={<FyersCallback />} />
               <Route path="/" element={<Navigate to="/dashboard" replace />} />
               <Route
                 path="/dashboard"

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -13,6 +13,7 @@ import { ThemeProvider } from "@/contexts/ThemeContext";
 import { AlertProvider } from "@/contexts/AlertContext";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import Login from "./pages/Login";
+import FyersCallback from "./pages/FyersCallback";
 import Dashboard from "./pages/Dashboard";
 import OptionChain from "./pages/OptionChain";
 import Analysis from "./pages/Analysis";

--- a/client/pages/FyersCallback.tsx
+++ b/client/pages/FyersCallback.tsx
@@ -1,0 +1,203 @@
+import { useState, useEffect } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Copy, CheckCircle, AlertCircle, ArrowLeft } from "lucide-react";
+
+export default function FyersCallback() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [authCode, setAuthCode] = useState("");
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    // Extract auth code from URL parameters
+    const code = searchParams.get("auth_code") || searchParams.get("code");
+    const state = searchParams.get("state");
+    const errorParam = searchParams.get("error");
+    const errorDescription = searchParams.get("error_description");
+
+    if (errorParam) {
+      setError(
+        errorDescription 
+          ? `Authentication failed: ${errorDescription}` 
+          : `Authentication failed: ${errorParam}`
+      );
+    } else if (code) {
+      setAuthCode(code);
+    } else {
+      setError("No authorization code found in the URL. Please restart the authentication process.");
+    }
+  }, [searchParams]);
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(authCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+      // Fallback for older browsers
+      const textArea = document.createElement("textarea");
+      textArea.value = authCode;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textArea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleGoBack = () => {
+    navigate("/login");
+  };
+
+  const handleOpenLogin = () => {
+    // Open login page in a new tab with a flag to show manual auth
+    window.open("/login?show_manual_auth=true", "_blank");
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="flex flex-col space-y-2 text-center">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Fyers Authentication
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {authCode ? "Authentication code received" : "Processing authentication"}
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              {authCode ? (
+                <>
+                  <CheckCircle className="h-5 w-5 text-green-600" />
+                  Authorization Code
+                </>
+              ) : (
+                <>
+                  <AlertCircle className="h-5 w-5 text-red-600" />
+                  Authentication Error
+                </>
+              )}
+            </CardTitle>
+            <CardDescription>
+              {authCode 
+                ? "Copy this code and paste it in the login form to complete authentication."
+                : "There was an issue with the authentication process."
+              }
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            {authCode && (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="authCode">Authorization Code</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      id="authCode"
+                      value={authCode}
+                      readOnly
+                      className="font-mono text-sm"
+                    />
+                    <Button
+                      onClick={copyToClipboard}
+                      variant="outline"
+                      size="icon"
+                      disabled={copied}
+                    >
+                      {copied ? (
+                        <CheckCircle className="h-4 w-4 text-green-600" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </div>
+                  {copied && (
+                    <p className="text-xs text-green-600">
+                      Code copied to clipboard!
+                    </p>
+                  )}
+                </div>
+
+                <Alert>
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>
+                    <strong>Next Steps:</strong>
+                    <ol className="list-decimal list-inside mt-2 space-y-1 text-sm">
+                      <li>Copy the authorization code above</li>
+                      <li>Go back to the login page</li>
+                      <li>Paste the code in the "Authorization Code" field</li>
+                      <li>Click "Authenticate with Code"</li>
+                    </ol>
+                  </AlertDescription>
+                </Alert>
+              </>
+            )}
+
+            <div className="flex gap-2">
+              <Button
+                onClick={handleGoBack}
+                variant="outline"
+                className="flex-1"
+              >
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back to Login
+              </Button>
+              
+              {authCode && (
+                <Button
+                  onClick={handleOpenLogin}
+                  className="flex-1"
+                >
+                  Open Login in New Tab
+                </Button>
+              )}
+            </div>
+
+            {authCode && (
+              <div className="p-3 bg-muted rounded-lg">
+                <h4 className="text-sm font-medium mb-2">Alternative Method:</h4>
+                <p className="text-xs text-muted-foreground">
+                  You can also manually copy this URL and extract the code yourself:
+                </p>
+                <code className="text-xs break-all bg-background p-2 rounded mt-2 block">
+                  {window.location.href}
+                </code>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <div className="text-center text-xs text-muted-foreground">
+          <p>
+            This page was opened automatically after Fyers authentication.
+            <br />
+            Keep this window open while you complete the login process.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/pages/FyersCallback.tsx
+++ b/client/pages/FyersCallback.tsx
@@ -29,14 +29,16 @@ export default function FyersCallback() {
 
     if (errorParam) {
       setError(
-        errorDescription 
-          ? `Authentication failed: ${errorDescription}` 
-          : `Authentication failed: ${errorParam}`
+        errorDescription
+          ? `Authentication failed: ${errorDescription}`
+          : `Authentication failed: ${errorParam}`,
       );
     } else if (code) {
       setAuthCode(code);
     } else {
-      setError("No authorization code found in the URL. Please restart the authentication process.");
+      setError(
+        "No authorization code found in the URL. Please restart the authentication process.",
+      );
     }
   }, [searchParams]);
 
@@ -76,7 +78,9 @@ export default function FyersCallback() {
             Fyers Authentication
           </h1>
           <p className="text-sm text-muted-foreground">
-            {authCode ? "Authentication code received" : "Processing authentication"}
+            {authCode
+              ? "Authentication code received"
+              : "Processing authentication"}
           </p>
         </div>
 
@@ -96,10 +100,9 @@ export default function FyersCallback() {
               )}
             </CardTitle>
             <CardDescription>
-              {authCode 
+              {authCode
                 ? "Copy this code and paste it in the login form to complete authentication."
-                : "There was an issue with the authentication process."
-              }
+                : "There was an issue with the authentication process."}
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -165,12 +168,9 @@ export default function FyersCallback() {
                 <ArrowLeft className="mr-2 h-4 w-4" />
                 Back to Login
               </Button>
-              
+
               {authCode && (
-                <Button
-                  onClick={handleOpenLogin}
-                  className="flex-1"
-                >
+                <Button onClick={handleOpenLogin} className="flex-1">
                   Open Login in New Tab
                 </Button>
               )}
@@ -178,9 +178,12 @@ export default function FyersCallback() {
 
             {authCode && (
               <div className="p-3 bg-muted rounded-lg">
-                <h4 className="text-sm font-medium mb-2">Alternative Method:</h4>
+                <h4 className="text-sm font-medium mb-2">
+                  Alternative Method:
+                </h4>
                 <p className="text-xs text-muted-foreground">
-                  You can also manually copy this URL and extract the code yourself:
+                  You can also manually copy this URL and extract the code
+                  yourself:
                 </p>
                 <code className="text-xs break-all bg-background p-2 rounded mt-2 block">
                   {window.location.href}

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -376,32 +376,42 @@ export default function Login() {
                   )}
                 </Button>
 
-                {showManualAuth && oauthUrl && (
-                  <div className="space-y-3 p-4 bg-muted rounded-lg">
-                    <div className="flex gap-2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        className="flex-1"
-                        onClick={() => window.open(oauthUrl, "_blank")}
-                        disabled={loading}
-                      >
-                        <ExternalLink className="mr-2 h-4 w-4" />
-                        Open OAuth
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        onClick={() => {
-                          setShowManualAuth(false);
-                          setManualAuthCode("");
-                          setOauthUrl("");
-                        }}
-                        disabled={loading}
-                      >
-                        Cancel
-                      </Button>
+                {showManualAuth && (
+                  <div className="space-y-4 p-4 bg-primary/5 border border-primary/20 rounded-lg">
+                    <div className="text-center">
+                      <h3 className="font-medium text-primary">Step 2: Complete Authentication</h3>
+                      <p className="text-sm text-muted-foreground mt-1">
+                        The OAuth page has opened in a new tab. Complete the authentication there, then return here.
+                      </p>
                     </div>
+
+                    {oauthUrl && (
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="flex-1"
+                          onClick={() => window.open(oauthUrl, "_blank")}
+                          disabled={loading}
+                        >
+                          <ExternalLink className="mr-2 h-4 w-4" />
+                          Reopen OAuth
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={() => {
+                            setShowManualAuth(false);
+                            setManualAuthCode("");
+                            setOauthUrl("");
+                            setError("");
+                          }}
+                          disabled={loading}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    )}
 
                     <div className="space-y-2">
                       <Label htmlFor="authCode">Authorization Code</Label>
@@ -410,13 +420,12 @@ export default function Login() {
                         type="text"
                         value={manualAuthCode}
                         onChange={(e) => setManualAuthCode(e.target.value)}
-                        placeholder="Paste the authorization code here"
+                        placeholder="Paste the authorization code from the callback page"
                         disabled={loading}
+                        className="font-mono"
                       />
                       <p className="text-xs text-muted-foreground">
-                        After completing OAuth authentication, copy the
-                        authorization code from the callback URL and paste it
-                        here.
+                        After completing OAuth authentication in the new tab, copy the authorization code from the callback page and paste it here.
                       </p>
                     </div>
 
@@ -426,7 +435,7 @@ export default function Login() {
                       onClick={handleManualAuthCode}
                       disabled={loading || !manualAuthCode.trim()}
                     >
-                      {loading ? "Processing..." : "Authenticate with Code"}
+                      {loading ? "Processing..." : "Complete Authentication"}
                     </Button>
                   </div>
                 )}

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -61,7 +61,9 @@ export default function Login() {
     } else if (showManualAuth === "true") {
       // Show manual auth input if coming from callback page
       setShowManualAuth(true);
-      setError("Paste the authorization code from the Fyers callback page to complete authentication.");
+      setError(
+        "Paste the authorization code from the Fyers callback page to complete authentication.",
+      );
     }
   }, [searchParams, navigate]);
 
@@ -379,9 +381,12 @@ export default function Login() {
                 {showManualAuth && (
                   <div className="space-y-4 p-4 bg-primary/5 border border-primary/20 rounded-lg">
                     <div className="text-center">
-                      <h3 className="font-medium text-primary">Step 2: Complete Authentication</h3>
+                      <h3 className="font-medium text-primary">
+                        Step 2: Complete Authentication
+                      </h3>
                       <p className="text-sm text-muted-foreground mt-1">
-                        The OAuth page has opened in a new tab. Complete the authentication there, then return here.
+                        The OAuth page has opened in a new tab. Complete the
+                        authentication there, then return here.
                       </p>
                     </div>
 
@@ -425,7 +430,9 @@ export default function Login() {
                         className="font-mono"
                       />
                       <p className="text-xs text-muted-foreground">
-                        After completing OAuth authentication in the new tab, copy the authorization code from the callback page and paste it here.
+                        After completing OAuth authentication in the new tab,
+                        copy the authorization code from the callback page and
+                        paste it here.
                       </p>
                     </div>
 

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -38,12 +38,13 @@ export default function Login() {
   const [debugInfo, setDebugInfo] = useState<any>(null);
   const [showDebug, setShowDebug] = useState(false);
 
-  // Handle OAuth callback
+  // Handle OAuth callback and URL parameters
   useEffect(() => {
     const token = searchParams.get("token");
     const status = searchParams.get("status");
     const mode = searchParams.get("mode");
     const errorMessage = searchParams.get("message");
+    const showManualAuth = searchParams.get("show_manual_auth");
 
     if (status === "success" && token) {
       // Clear any existing errors
@@ -57,6 +58,10 @@ export default function Login() {
       setError(decodeURIComponent(errorMessage));
       // Clear the URL parameters to prevent loops
       navigate("/login", { replace: true });
+    } else if (showManualAuth === "true") {
+      // Show manual auth input if coming from callback page
+      setShowManualAuth(true);
+      setError("Paste the authorization code from the Fyers callback page to complete authentication.");
     }
   }, [searchParams, navigate]);
 

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -152,11 +152,14 @@ export default function Login() {
       });
 
       if (result.success && result.auth_url) {
-        // Show manual auth code option and open OAuth in new tab
+        // Automatically open OAuth in new tab
+        window.open(result.auth_url, "_blank");
+
+        // Show manual auth code option
         setOauthUrl(result.auth_url);
         setShowManualAuth(true);
         setError(
-          "OAuth URL generated. You can either click 'Open OAuth' or manually enter the auth code below after completing authentication.",
+          "OAuth authentication opened in a new tab. After completing authentication, you will be redirected to a page with the authorization code. Copy the code and paste it in the field below to complete login.",
         );
       } else {
         setError(result.message || "Failed to initiate OAuth");

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "dev": "vite",
     "dev:python": "python python_backend/main.py",
+    "callback-server": "python python_backend/fyers_callback.py",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build",
     "build:server": "vite build --config vite.config.server.ts",

--- a/python_backend/fyers_callback.py
+++ b/python_backend/fyers_callback.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Simple Flask server to handle Fyers OAuth callback and redirect to React app
+This runs on port 5000 to match the Fyers callback URL: http://127.0.0.1:5000/fyers/callback
+"""
+
+from flask import Flask, request, redirect, render_template_string
+import urllib.parse
+import sys
+import logging
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+
+# HTML template for the callback page
+CALLBACK_HTML = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fyers Authentication - Redirecting...</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+            background: #f8fafc;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+        }
+        .container {
+            background: white;
+            border-radius: 8px;
+            padding: 40px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            max-width: 500px;
+        }
+        .success {
+            color: #10b981;
+            font-size: 48px;
+            margin-bottom: 20px;
+        }
+        .error {
+            color: #ef4444;
+            font-size: 48px;
+            margin-bottom: 20px;
+        }
+        h1 {
+            color: #1f2937;
+            margin-bottom: 10px;
+        }
+        p {
+            color: #6b7280;
+            margin-bottom: 20px;
+            line-height: 1.6;
+        }
+        .code-box {
+            background: #f3f4f6;
+            border: 1px solid #d1d5db;
+            border-radius: 6px;
+            padding: 12px;
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-size: 14px;
+            word-break: break-all;
+            margin: 20px 0;
+        }
+        .button {
+            background: #3b82f6;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 6px;
+            cursor: pointer;
+            text-decoration: none;
+            display: inline-block;
+            margin: 10px;
+            font-size: 14px;
+        }
+        .button:hover {
+            background: #2563eb;
+        }
+        .button-secondary {
+            background: #6b7280;
+        }
+        .button-secondary:hover {
+            background: #4b5563;
+        }
+        .spinner {
+            border: 2px solid #f3f3f3;
+            border-top: 2px solid #3b82f6;
+            border-radius: 50%;
+            width: 20px;
+            height: 20px;
+            animation: spin 1s linear infinite;
+            display: inline-block;
+            margin-right: 10px;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        {% if auth_code %}
+            <div class="success">✅</div>
+            <h1>Authentication Successful!</h1>
+            <p>Your Fyers authorization code has been received:</p>
+            <div class="code-box">{{ auth_code }}</div>
+            <p>
+                You will be automatically redirected to the login page in <span id="countdown">5</span> seconds,
+                or you can click the button below to continue immediately.
+            </p>
+            <a href="{{ redirect_url }}" class="button">Continue to Login</a>
+            <button onclick="copyCode()" class="button button-secondary">Copy Code</button>
+        {% else %}
+            <div class="error">❌</div>
+            <h1>Authentication Error</h1>
+            <p>{{ error_message }}</p>
+            <p>Please try again or contact support if the issue persists.</p>
+            <a href="http://localhost:8080/login" class="button">Back to Login</a>
+        {% endif %}
+    </div>
+
+    <script>
+        {% if auth_code %}
+        // Auto-redirect countdown
+        let countdown = 5;
+        const countdownElement = document.getElementById('countdown');
+        
+        const timer = setInterval(() => {
+            countdown--;
+            countdownElement.textContent = countdown;
+            
+            if (countdown <= 0) {
+                clearInterval(timer);
+                window.location.href = '{{ redirect_url }}';
+            }
+        }, 1000);
+        
+        // Copy code function
+        function copyCode() {
+            const code = '{{ auth_code }}';
+            navigator.clipboard.writeText(code).then(() => {
+                alert('Authorization code copied to clipboard!');
+            }).catch(() => {
+                // Fallback for older browsers
+                const textArea = document.createElement('textarea');
+                textArea.value = code;
+                document.body.appendChild(textArea);
+                textArea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textArea);
+                alert('Authorization code copied to clipboard!');
+            });
+        }
+        {% endif %}
+    </script>
+</body>
+</html>
+"""
+
+@app.route('/fyers/callback')
+def fyers_callback():
+    """Handle Fyers OAuth callback and redirect to React app with auth code"""
+    try:
+        # Get parameters from the callback URL
+        auth_code = request.args.get('auth_code') or request.args.get('code')
+        state = request.args.get('state')
+        error = request.args.get('error')
+        error_description = request.args.get('error_description')
+        
+        logger.info(f"Fyers callback received - Code: {'***' if auth_code else 'None'}, Error: {error}")
+        
+        if error:
+            error_message = error_description or f"Authentication failed: {error}"
+            logger.error(f"OAuth error: {error_message}")
+            return render_template_string(CALLBACK_HTML, 
+                                        auth_code=None, 
+                                        error_message=error_message)
+        
+        if auth_code:
+            # Prepare redirect URL to React app with auth code
+            react_app_url = "http://localhost:8080/fyers/callback"
+            params = {
+                'auth_code': auth_code,
+                'state': state if state else ''
+            }
+            redirect_url = f"{react_app_url}?{urllib.parse.urlencode(params)}"
+            
+            logger.info(f"Successful OAuth callback, redirecting to: {react_app_url}")
+            
+            return render_template_string(CALLBACK_HTML, 
+                                        auth_code=auth_code,
+                                        error_message=None,
+                                        redirect_url=redirect_url)
+        else:
+            error_message = "No authorization code received from Fyers"
+            logger.error(error_message)
+            return render_template_string(CALLBACK_HTML, 
+                                        auth_code=None, 
+                                        error_message=error_message)
+            
+    except Exception as e:
+        error_message = f"Callback processing error: {str(e)}"
+        logger.error(error_message)
+        return render_template_string(CALLBACK_HTML, 
+                                    auth_code=None, 
+                                    error_message=error_message)
+
+@app.route('/health')
+def health_check():
+    """Health check endpoint"""
+    return {"status": "healthy", "message": "Fyers callback server is running"}
+
+@app.route('/')
+def index():
+    """Root endpoint with information"""
+    return {
+        "service": "Fyers OAuth Callback Server",
+        "callback_url": "http://127.0.0.1:5000/fyers/callback",
+        "status": "running",
+        "instructions": "This server handles Fyers OAuth callbacks and redirects to the React app"
+    }
+
+if __name__ == '__main__':
+    print("Starting Fyers OAuth Callback Server...")
+    print("Callback URL: http://127.0.0.1:5000/fyers/callback")
+    print("This server will handle Fyers OAuth redirects and forward to the React app")
+    print("Make sure your React app is running on http://localhost:8080")
+    print("-" * 50)
+    
+    try:
+        app.run(host='127.0.0.1', port=5000, debug=True)
+    except KeyboardInterrupt:
+        print("\nShutting down Fyers callback server...")
+    except Exception as e:
+        print(f"Error starting server: {e}")
+        sys.exit(1)

--- a/python_backend/requirements.txt
+++ b/python_backend/requirements.txt
@@ -2,6 +2,7 @@
 fastapi>=0.104.0
 uvicorn[standard]>=0.24.0
 websockets>=12.0
+flask>=3.0.0
 
 # Data processing and analysis
 pandas>=2.0.0

--- a/server/routes/fyers-auth.ts
+++ b/server/routes/fyers-auth.ts
@@ -51,7 +51,7 @@ def authenticate_fyers_v3(app_id, secret_id, pin):
             session = fyersModel.SessionModel(
                 client_id=app_id,
                 secret_key=secret_id,
-                redirect_uri="http://localhost:8080/api/auth/fyers/callback",
+                redirect_uri="http://127.0.0.1:5000/fyers/callback",
                 response_type="code",
                 grant_type="authorization_code"
             )
@@ -178,7 +178,7 @@ def process_oauth_callback_v3(auth_code, app_id, secret_id, pin):
             session = fyersModel.SessionModel(
                 client_id=app_id,
                 secret_key=secret_id,
-                redirect_uri="http://localhost:8080/api/auth/fyers/callback",
+                redirect_uri="http://127.0.0.1:5000/fyers/callback",
                 response_type="code",
                 grant_type="authorization_code"
             )
@@ -361,7 +361,7 @@ def initiate_oauth_v3(app_id, secret_id):
             session = fyersModel.SessionModel(
                 client_id=app_id,
                 secret_key=secret_id,
-                redirect_uri="http://localhost:8080/api/auth/fyers/callback",
+                redirect_uri="http://127.0.0.1:5000/fyers/callback",
                 response_type="code",
                 grant_type="authorization_code"
             )
@@ -460,7 +460,7 @@ def process_manual_auth_code_v3(auth_code, app_id, secret_id, pin):
             session = fyersModel.SessionModel(
                 client_id=app_id,
                 secret_key=secret_id,
-                redirect_uri="http://localhost:8080/api/auth/fyers/callback",
+                redirect_uri="http://127.0.0.1:5000/fyers/callback",
                 response_type="code",
                 grant_type="authorization_code"
             )


### PR DESCRIPTION
## Purpose

The user requested to fix authentication issues by implementing a manual authentication flow for Fyers OAuth. The goal was to create a system where users can manually enter the authorization code by redirecting to a dedicated callback page, allowing them to complete authentication even when automatic OAuth flow fails.

## Code changes

- **Added new React component** `FyersCallback.tsx` that handles OAuth callback redirects and displays the authorization code for manual entry
- **Updated routing** in `App.tsx` to include the new `/fyers/callback` route
- **Enhanced Login component** to support manual authentication mode with URL parameter detection (`show_manual_auth=true`)
- **Created Flask callback server** (`fyers_callback_server.py`) to handle OAuth redirects at `http://127.0.0.1:5000/fyers/callback`
- **Updated redirect URIs** across all Fyers authentication functions to use the new callback server endpoint
- **Added Flask dependency** to `requirements.txt` for the callback server

The implementation provides a robust fallback authentication method where users can copy the authorization code from the callback page and paste it into the login form to complete authentication manually.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/bf96d47356d04629869b62246420d9f1/cosmos-home)

👀 [Preview Link](https://bf96d47356d04629869b62246420d9f1-cosmos-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bf96d47356d04629869b62246420d9f1</projectId>-->
<!--<branchName>cosmos-home</branchName>-->